### PR TITLE
Added useQuery for use with fetching

### DIFF
--- a/features/transcription/components/AudioRecorder.tsx
+++ b/features/transcription/components/AudioRecorder.tsx
@@ -37,7 +37,7 @@ const AudioRecorder = ({ stream, startRecording, stopRecording }) => {
             aria-label='Stop Recording'
             height={16}
             width={16}
-            bg={{ bg: 'red.500' }}
+            bg={'red.500'}
             _hover={{ bg: 'red.600' }}
             _pressed={{ bg: 'red.700' }}
             borderRadius={'50%'}

--- a/features/transcription/helpers/queryVietTranscription.ts
+++ b/features/transcription/helpers/queryVietTranscription.ts
@@ -12,13 +12,18 @@ type HuggingFaceAPIResult = {
 
 type HuggingFaceAPIResponse = HuggingFaceAPIError | HuggingFaceAPIResult
 
-export const queryVietTranscription = async (data: ArrayBuffer): Promise<HuggingFaceAPIResult> => {
-  const response = await fetch('http://localhost:8000/recognize', {
-    method: 'POST',
-    body: data,
-  })
-  const result = await response.json()
-  return result as HuggingFaceAPIResult
+export const queryVietTranscription = async (
+  data: ArrayBuffer | null,
+): Promise<HuggingFaceAPIResult> => {
+  if (data) {
+    const response = await fetch('http://localhost:8000/recognize', {
+      method: 'POST',
+      body: data,
+    })
+    const result = await response.json()
+    return result as HuggingFaceAPIResult
+  }
+  return { text: 'Endpoint expected wav byte data' }
 }
 
 // Method to be used with HuggingFaceAPI's that requires a retry until model is up and running

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,16 @@ import '@/styles/globals.css'
 import { ChakraProvider } from '@chakra-ui/react'
 import type { AppProps } from 'next/app'
 import type { ReactElement } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
 
 export default function App({ Component, pageProps }: AppProps): ReactElement {
   return (
-    <ChakraProvider>
-      <Component {...pageProps} />
-    </ChakraProvider>
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider>
+        <Component {...pageProps} />
+      </ChakraProvider>
+    </QueryClientProvider>
   )
 }


### PR DESCRIPTION
### Goal:
- [x] Replace the use of fetches with `useQuery`
- [ ] Ensure frontend render variables take advantage of state return by useQuery

### End Result:
`useQuery` is used in place of less safer `fetch` with `refetch()` used as method for fetching the Vietnamese transcription from the server